### PR TITLE
Updated cloudflare related http requests

### DIFF
--- a/CloudflareSample/README.md
+++ b/CloudflareSample/README.md
@@ -29,9 +29,7 @@
        
     2. `cmRegion` - your Certificate Manager service instance region value. Can be one of: `us-south`, `eu-gb`, `eu-de`, `jp-tok`  
         E.g. `"us-south"`
- 
-    3. `cloudflareEmail` - email address associated with your account
-    
+     
     4. `cloudflareApiKey` - API key generated on the "My Account" page
  
 4. In the **Endpoints** sidebar, tick the **Enable as Web Action** checkbox

--- a/CloudflareSample/README.md
+++ b/CloudflareSample/README.md
@@ -30,7 +30,7 @@
     2. `cmRegion` - your Certificate Manager service instance region value. Can be one of: `us-south`, `eu-gb`, `eu-de`, `jp-tok`  
         E.g. `"us-south"`
      
-    4. `cloudflareApiKey` - API key generated on the "My Account" page
+    3. `cloudflareApiKey` - API key generated on the "My Account" page
  
 4. In the **Endpoints** sidebar, tick the **Enable as Web Action** checkbox
  

--- a/CloudflareSample/main.js
+++ b/CloudflareSample/main.js
@@ -49,8 +49,7 @@ const addTxtRecord = async (zoneId, domain, payload, userInfo) => {
         method: 'POST',
         uri: `${cloudflareBaseurl}/zones/${zoneId}/dns_records`,
         headers: {
-            'X-Auth-Email': userInfo.cloudflareEmail,
-            'X-Auth-Key': userInfo.cloudflareApiKey,
+            'Authorization': `Bearer ${userInfo.cloudflareApiKey}`,
             'Content-Type': 'application/json'
         },
         json: {
@@ -94,8 +93,7 @@ const getZoneIdByDomain = async (domain, userInfo) => {
         method: 'GET',
         uri: `${cloudflareBaseurl}/zones?name=${encodeURIComponent(domain)}&status=active`,
         headers: {
-            'X-Auth-Email': userInfo.cloudflareEmail,
-            'X-Auth-Key': userInfo.cloudflareApiKey,
+            'Authorization': `Bearer ${userInfo.cloudflareApiKey}`,
             'Content-Type': 'application/json'
         }
     };
@@ -135,8 +133,7 @@ const getTxtRecords = async (zoneId, domain, payload, userInfo) => {
         method: 'GET',
         uri: `${cloudflareBaseurl}/zones/${zoneId}/dns_records?type=TXT&name=${recordName}.${encodeURIComponent(domain)}&content=${encodeURIComponent(recordValue)}`,
         headers: {
-            'X-Auth-Email': userInfo.cloudflareEmail,
-            'X-Auth-Key': userInfo.cloudflareApiKey,
+            'Authorization': `Bearer ${userInfo.cloudflareApiKey}`,
             'Content-Type': 'application/json'
         }
     };
@@ -169,8 +166,7 @@ const removeTxtRecord = async (zoneId, recordId, userInfo) => {
         method: 'DELETE',
         uri: `${cloudflareBaseurl}/zones/${zoneId}/dns_records/${recordId}`,
         headers: {
-            'X-Auth-Email': userInfo.cloudflareEmail,
-            'X-Auth-Key': userInfo.cloudflareApiKey,
+            'Authorization': `Bearer ${userInfo.cloudflareApiKey}`,
             'Content-Type': 'application/json'
         }
     };
@@ -249,7 +245,6 @@ const main = async (params)=> {
         const publicKey = await getPublicKey(body, certificateManagerApiUrl);
         const decodedNotification = await jwtVerify(params.data, publicKey);
         const userInfo = {
-            cloudflareEmail: params.cloudflareEmail,
             cloudflareApiKey: params.cloudflareApiKey
         };
 


### PR DESCRIPTION
Cloudflare has changed their authentication flow for their api. They now use an Authorization header and do not require an email. I also removed the cloudflareEmail step from the readme.

I accidentally created another unfinished pull request due to an accidental button click, sorry.